### PR TITLE
VampireWindowFIx

### DIFF
--- a/Content.Server/_RPSX/GameRules/Vampire/EUI/VampireAbilitiesEUI.cs
+++ b/Content.Server/_RPSX/GameRules/Vampire/EUI/VampireAbilitiesEUI.cs
@@ -2,6 +2,7 @@
 using Content.Server.EUI;
 using Content.Shared.Eui;
 using Content.Shared.RPSX.DarkForces.Vampire;
+using Content.Shared.RPSX.DarkForces.Vampire.Components;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -11,6 +12,15 @@ namespace Content.Server.RPSX.GameRules.Vampire.EUI;
 [UsedImplicitly]
 public sealed class VampireAbilitiesEUI : BaseEui
 {
+    [Dependency] private readonly EntityManager _entityManager = default!;
+    private readonly EntityUid _owner;
+
+    public VampireAbilitiesEUI(EntityUid owner)
+    {
+        IoCManager.InjectDependencies(this);
+        _owner = owner;
+    }
+
     public override void HandleMessage(EuiMessageBase msg)
     {
         base.HandleMessage(msg);
@@ -18,11 +28,18 @@ public sealed class VampireAbilitiesEUI : BaseEui
         if (msg is not VampireAbilitySelected data)
             return;
 
-        var entityManager = IoCManager.Resolve<IEntityManager>();
-        var entityUid = entityManager.GetEntity(data.NetEntity);
+        var entityUid = _entityManager.GetEntity(data.NetEntity);
         var ev = new VampireAbilitySelectedEvent(data.Action, data.BloodRequired, data.ReplaceId);
 
-        entityManager.EventBus.RaiseLocalEvent(entityUid, ref ev);
+        _entityManager.EventBus.RaiseLocalEvent(entityUid, ref ev);
         Close();
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+
+        if (_entityManager.EntityExists(_owner) && _entityManager.TryGetComponent<VampireComponent>(_owner, out var comp))
+            comp.AbilitiesUiOpen = false;
     }
 }

--- a/Content.Server/_RPSX/GameRules/Vampire/Role/VampireSystem.cs
+++ b/Content.Server/_RPSX/GameRules/Vampire/Role/VampireSystem.cs
@@ -96,7 +96,11 @@ public sealed partial class VampireSystem : EntitySystem
             return;
 
         var session = actor.PlayerSession;
-        var ui = new VampireAbilitiesEUI();
+
+        if (component.AbilitiesUiOpen)
+            return;
+
+        var ui = new VampireAbilitiesEUI(uid);
         var state = new VampireAbilitiesState(
             GetNetEntity(uid),
             GetOpenedAbilities(uid, component),
@@ -107,6 +111,7 @@ public sealed partial class VampireSystem : EntitySystem
         _euiManager.OpenEui(ui, session);
         ui.SendMessage(state);
 
+        component.AbilitiesUiOpen = true;
         args.Handled = true;
     }
 

--- a/Content.Shared/_RPSX/DarkForces/Vampire/Components/VampireComponent.cs
+++ b/Content.Shared/_RPSX/DarkForces/Vampire/Components/VampireComponent.cs
@@ -68,4 +68,7 @@ public sealed partial class VampireComponent : Component
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<FactionIconPrototype> StatusIcon { get; set; } = "VampireIcon";
+
+    [DataField]
+    public bool AbilitiesUiOpen;
 }


### PR DESCRIPTION
Фикс сделан так -

В компонент добавлено булевое значение

при попытке открыть юишку проверяется открыто ли у нас окно ( true ли булевое значение )
если нет то юишка открывается, значение меняется на true
в самой юишке сделано так что при ее закрытии булевое значение меняется обратно на false

Метод по сути является некой заплаткой до времен полного рефактора систем вампира 